### PR TITLE
correct logic for build restrictions

### DIFF
--- a/lib/vx/service_connector/model.rb
+++ b/lib/vx/service_connector/model.rb
@@ -41,7 +41,7 @@ module Vx
           if restriction.nil?
             # skip internal pr or tag
             # allow all pushes and foreign pr
-            return !tag?
+            return (!internal_pull_request? || !tag?)
           end
 
           if restriction.is_a?(Hash)
@@ -49,7 +49,10 @@ module Vx
             pr        = restriction[:pull_request]
 
             if branch_re && Regexp.new(branch_re).match(branch)
-              return true
+              # if branch name matches
+              # we're already building it,
+              # so we should ignore prs.
+              return !internal_pull_request?
             end
 
             if pr && pull_request?
@@ -65,11 +68,7 @@ module Vx
         end
 
         def ignore?
-          !!(
-              skip                   ||
-              internal_pull_request? ||
-              message.to_s =~ PAYLOAD_IGNORE_RE
-            )
+          !!(skip || message.to_s =~ PAYLOAD_IGNORE_RE)
         end
 
         def tag?

--- a/lib/vx/service_connector/version.rb
+++ b/lib/vx/service_connector/version.rb
@@ -1,5 +1,5 @@
 module Vx
   module ServiceConnector
-    VERSION = "0.4.7"
+    VERSION = "0.4.8"
   end
 end

--- a/spec/lib/bitbucket_payload_spec.rb
+++ b/spec/lib/bitbucket_payload_spec.rb
@@ -27,6 +27,28 @@ describe Vx::ServiceConnector::Bitbucket::Payload do
     its(:web_url)             { should eq url }
   end
 
+
+  context 'create pull_request' do
+    let(:content) { read_json_fixture 'bitbucket/payload/created_pull_request' }
+    let(:url)     { 'https://bitbucket.org/121111foobar/vx-promo/pull-request/1' }
+    let(:sha)     { 'b14806535f5e' }
+
+    before do
+      mock_get_commit '121111foobar/vx-promo', sha
+    end
+
+    its(:ignore?)             { should be_false }
+    its(:pull_request?)       { should be_true }
+    its(:pull_request_number) { should eq 1 }
+    its(:branch)              { should eq 'test' }
+    its(:branch_label)        { should eq 'test' }
+    its(:sha)                 { should eq sha }
+    its(:message)             { should eq 'Fix all the bugs' }
+    its(:author)              { should eq 'login' }
+    its(:author_email)        { should eq 'example@gmail.com' }
+    its(:web_url)             { should eq url }
+  end
+
   context 'declined pull request' do
     let(:content) { read_json_fixture('bitbucket/payload/declined_pull_request') }
 
@@ -69,7 +91,7 @@ describe Vx::ServiceConnector::Bitbucket::Payload do
        mock_get_commit '121111foobar/vx-promo', 'b14806535f5e'
     end
 
-    its(:ignore?) { should be_true }
+    its(:ignore?) { should be_false }
   end
 
   context 'push with empty commits' do

--- a/spec/lib/github_payload_spec.rb
+++ b/spec/lib/github_payload_spec.rb
@@ -32,6 +32,29 @@ describe Vx::ServiceConnector::Github::Payload do
     its(:tag)                 { should be_nil }
   end
 
+  context "internal pull_request" do
+    let(:content) { read_json_fixture("github/payload/pull_request") }
+    let(:url)     { "https://github.com/evrone/cybergifts/pull/177" }
+    let(:sha)     { '84158c732ff1af3db9775a37a74ddc39f5c4078f' }
+
+    before do
+      mock_get_commit 'evrone/cybergifts', sha
+    end
+
+    its(:pull_request?)         { should be_true }
+    its(:foreign_pull_request?) { should be_false }
+    its(:internal_pull_request?){ should be_true }
+    its(:pull_request_number)   { should eq 177 }
+    its(:sha)                   { should eq sha }
+    its(:branch)                { should eq 'test' }
+    its(:branch_label)          { should eq 'dima-exe:test' }
+    its(:message)               { should eq 'Fix all the bugs' }
+    its(:author)                { should eq 'Monalisa Octocat' }
+    its(:author_email)          { should eq 'support@github.com' }
+    its(:web_url)               { should eq url }
+    its(:ignore?)               { should be_false }
+  end
+
   context "Octokit exceptions" do
     let(:content) { read_json_fixture("github/payload/pull_request") }
     let(:url)     { "https://github.com/evrone/cybergifts/pull/177" }

--- a/spec/lib/model_spec.rb
+++ b/spec/lib/model_spec.rb
@@ -47,7 +47,7 @@ describe "(models)" do
         # deny, internal pr
         instance(
           params.merge(internal_pull_request?: true)
-        ).to_not be_perform(nil)
+        ).to be_perform(nil)
       end
 
       it "restriction is hash" do
@@ -69,7 +69,21 @@ describe "(models)" do
         # pass, pr allowed
         instance(
           params.merge(internal_pull_request?: true)
-        ).not_to be_perform(pull_request: true)
+        ).to be_perform(pull_request: true)
+
+        instance(
+          params.merge(
+            internal_pull_request?: true,
+            branch: '(develop)'
+          )
+        ).not_to be_perform(branch: '$\(dev')
+
+        instance(
+          params.merge(
+            internal_pull_request?: true,
+            branch: '(develop)'
+          )
+        ).to be_perform(branch: 'master', pull_request: true)
 
         # deny, pr not allowed
         instance(


### PR DESCRIPTION
Нифига не правильно мы вчера сделали.

Кейс букмейта: у них стоит ограничение только на мастер, но есть галка на PR. Следовательно, они хотят билдить только мастер и все пуллы. Но пуллы не билдятся.

Кейс CC: они добавляют каждый бранч в настройки проекта, а когда делают PR, у них запускается 2 билда.

Следовательно, нам нужно билдить internal_pull_request?, если стоит галка PR в настройках. Но если бранч пришедшего коммита матчит бранч из настроек, и это пулл реквест, то нужно пропускать билд.

```ruby
        instance(
          params.merge(
            internal_pull_request?: true,
            branch: '(develop)'
          )
        ).not_to be_perform(branch: '$\(dev')

        instance(
          params.merge(
            internal_pull_request?: true,
            branch: '(develop)'
          )
        ).to be_perform(branch: 'master', pull_request: true)
```