### PR TITLE
refs #37 fix Bitbucket::Payload build

### DIFF
--- a/lib/vx/service_connector/bitbucket/payload.rb
+++ b/lib/vx/service_connector/bitbucket/payload.rb
@@ -3,6 +3,11 @@ module Vx
     class Bitbucket
       Payload = Struct.new(:session, :params) do
 
+        def initialize(*)
+          super
+          self.params ||= {} # Prevents nil passed
+        end
+
         def build
           ServiceConnector::Model::Payload.from_hash(
             internal_pull_request?: (pull_request? && !foreign_pull_request?),
@@ -153,7 +158,7 @@ module Vx
 
         def pull_request
           @pull_request ||= begin
-            params.first.last.is_a?(Hash) && params.first.last
+            params.first && params.first.last.is_a?(Hash) && params.first.last
           end
         end
 


### PR DESCRIPTION
Steps to reproduce

```
require 'spec_helper'

describe Vx::ServiceConnector::Bitbucket::Payload do

  include BitbucketWebMocks

  let(:content)    { read_json_fixture 'bitbucket/payload/push' }
  let(:bitbucket)  {
    Vx::ServiceConnector::Bitbucket.new 'login', Vx::ServiceConnector::Bitbucket::Session.test
  }
  let(:repo)       { create :repo }

  context "When empty hash passed as params" do
    it "is broken" do
      payload = bitbucket.payload(repo, {})
    end
  end

  context "When nil passed as params" do
    it "is broken" do
      payload = bitbucket.payload(repo, nil)
    end
  end
end
```